### PR TITLE
Concept of Service for shared code between API and Web controllers

### DIFF
--- a/src/Controllers/Api/DiscussionController.php
+++ b/src/Controllers/Api/DiscussionController.php
@@ -6,6 +6,7 @@ use Bitporch\Forum\Controllers\Controller;
 use Bitporch\Forum\Models\Discussion;
 use Bitporch\Forum\Requests\Discussions\CreateDiscussionRequest;
 use Bitporch\Forum\Requests\Discussions\UpdateDiscussionRequest;
+use Bitporch\Forum\Services\DiscussionService;
 
 class DiscussionController extends Controller
 {
@@ -23,12 +24,15 @@ class DiscussionController extends Controller
      * Store a newly created resource in storage.
      *
      * @param CreateDiscussionRequest $request
+     * @param DiscussionService $discussionService
      *
      * @return \Illuminate\Http\Response
      */
-    public function store(CreateDiscussionRequest $request)
+    public function store(CreateDiscussionRequest $request, DiscussionService $discussionService)
     {
-        $discussion = Discussion::create($request->all());
+        $discussion = $discussionService->store(
+            $request->user(), ['title' => $request->get('title')], ['content' => $request->get('content')], $request->get('group_id')
+        );
 
         return response($discussion, 201);
     }

--- a/src/Controllers/DiscussionController.php
+++ b/src/Controllers/DiscussionController.php
@@ -5,6 +5,7 @@ namespace Bitporch\Forum\Controllers;
 use Bitporch\Forum\Models\Discussion;
 use Bitporch\Forum\Requests\Discussions\CreateDiscussionRequest;
 use Bitporch\Forum\Requests\Discussions\UpdateDiscussionRequest;
+use Bitporch\Forum\Services\DiscussionService;
 
 class DiscussionController extends Controller
 {
@@ -32,22 +33,15 @@ class DiscussionController extends Controller
      * Store a newly created resource in storage.
      *
      * @param CreateDiscussionRequest $request
+     * @param DiscussionService $discussionService
      *
      * @return \Illuminate\Http\Response
      */
-    public function store(CreateDiscussionRequest $request)
+    public function store(CreateDiscussionRequest $request, DiscussionService $discussionService)
     {
-        $discussion = $request->user()
-            ->discussions()
-            ->create($request->only('title'));
-
-        $discussion->posts()->create([
-            'discussion_id' => $discussion->id,
-            'user_id'       => $request->user()->id,
-            'content'       => $request->content,
-        ]);
-
-        $discussion->groups()->attach($request->group_id);
+        $discussion = $discussionService->store(
+            $request->user(), ['title' => $request->get('title')], ['content' => $request->get('content')], $request->get('group_id')
+        );
 
         return redirect()->route('forum.discussions.show', $discussion->slug);
     }

--- a/src/Services/DiscussionService.php
+++ b/src/Services/DiscussionService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Bitporch\Forum\Services;
+
+use Bitporch\Forum\Models\Discussion;
+use Bitporch\Forum\Traits\ForumUser;
+use Illuminate\Support\Facades\Auth;
+
+class DiscussionService
+{
+
+    /**
+     * @param $user If PR-157 had been merged, we could type-hin the interface here
+     * @param array $discussionData
+     * @param array $postData
+     * @param $groupId
+     *
+     * @return Discussion
+     */
+    public function store($user, array $discussionData, array $postData, $groupId)
+    {
+        $discussion = $user
+            ->discussions()
+            ->create($discussionData);
+
+        $discussion->posts()->create(
+            array_merge([
+                'user_id' => $user->id,
+            ], $postData)
+        );
+
+        $discussion->groups()->attach($groupId);
+
+        return $discussion;
+    }
+
+    public function anotherStore(array $data, $groupId)
+    {
+        $discussion = $this->user()->discussions()->create($data);
+        $discussion->groups()->attach($groupId);
+
+        return $discussion;
+    }
+
+    /**
+     * This would be a method in a super-class that all services would extend
+     *
+     * @return ForumUser
+     */
+    protected function user()
+    {
+        // Make sure to resolve web and token authentication
+        return Auth::user();
+    }
+}


### PR DESCRIPTION
This is suppose to be just a proof of concept and not actual code to be merged.

Anytime a resource have more than one line of code for web and api controllers (repetitive), it is a candidate for a service class. The service class will contain the code that once would be repetitive and the controllers will just decode the request data into understandable data for the service.

The authenticated user can either be passed from the controller or resolved by the service itself through the Facade (Laravel facades are fakeable and testable) or a combination of both (if user not passed, assume the logged in one);

In `antoherStore` method I propose some drastic concept changes: let Discussion have a body/content, which would be the first post instead of creating a post record for the first post. 